### PR TITLE
2019-12-09 GUARD-325 Failed-Orders-Sync

### DIFF
--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>

--- a/src/EtsyAccess/Models/Transaction.cs
+++ b/src/EtsyAccess/Models/Transaction.cs
@@ -79,7 +79,7 @@ namespace EtsyAccess.Models
 		/// The numeric ID of the primary listing image for this transaction
 		/// </summary>
 		[JsonProperty("image_listing_id")]
-		public int ImageListingId { get; set; }
+		public long ImageListingId { get; set; }
 		/// <summary>
 		/// The numeric ID for the receipt associated to this transaction
 		/// </summary>


### PR DESCRIPTION
Summary
One of our customers faced Etsy's order's deserialization issue.

`Newtonsoft.Json.JsonReaderException: JSON integer 2147658883 is too large or small for an Int32. Path 'results[1].Transactions[0].image_listing_id', line 1, position 64978.`

Etsy's documentation contains mistake - https://www.etsy.com/developers/documentation/reference/transaction, it declares that this field should be int.