### PR TITLE
2020-07-28 GUARD-597 Tracking-Numbers

### DIFF
--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,15 +2,16 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.0.11</Version>
+    <Version>1.0.12</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
     <Description>Etsy webservices API wrapper</Description>
-    <Copyright>SkuVault © 2019</Copyright>
+    <Copyright>SkuVault © 2020</Copyright>
     <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
+    <AssemblyVersion>1.0.12.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/Models/Receipt.cs
+++ b/src/EtsyAccess/Models/Receipt.cs
@@ -188,6 +188,8 @@ namespace EtsyAccess.Models
 		/// </summary>
 		[JsonProperty("adjusted_grandtotal")]
 		public float AdjustedGrandTotal { get; set; }
+		[JsonProperty("shipped_date")]
+		public long? ShippedDate { get; set; }
 		[JsonProperty("shipping_details")]
 		public ShippingDetails ShippingDetails { get; set; }
 		/// <summary>
@@ -219,27 +221,45 @@ namespace EtsyAccess.Models
 		/// <summary>
 		/// Shipping carrier name
 		/// </summary>
+		[JsonProperty("carrier_name")]
 		public string CarrierName { get; set; }
 		/// <summary>
 		/// Receipt shipping id used internally
 		/// </summary>
-		public int ReceiptShippingId { get; set; }
+		[JsonProperty("receipt_shipping_id")]
+		public long ReceiptShippingId { get; set; }
 		/// <summary>
 		/// Tracking code for carrier
 		/// </summary>
+		[JsonProperty("tracking_code")]
 		public string TrackingCode { get; set; }
 		/// <summary>
 		/// Tracking URL for carrier's website
 		/// </summary>
+		[JsonProperty("tracking_url")]
 		public string TrackingUrl { get; set; }
 		/// <summary>
 		/// Optional note sent to buyer
 		/// </summary>
+		[JsonProperty("buyer_note")]
 		public string BuyerNote { get; set; }
 		/// <summary>
 		/// Date the notification was sent
 		/// </summary>
-		public long NotificationDate { get; set; }
+		[JsonProperty("notification_date")]
+		public long? NotificationDate { get; set; }
+		[JsonProperty("mailing_date")]
+		public long MailingDate { get; set; }
+		[JsonProperty("major_tracking_state")]
+		public string MajorTrackingState { get; set; }
+		[JsonProperty("mail_class")]
+		public string MailClass { get; set; }
+		[JsonProperty("is_etsy_only_tracking")]
+		public bool IsEtsyOnlyTracking { get; set; }
+		[JsonProperty("current_step")]
+		public string CurrentStep { get; set; }
+		[JsonProperty("current_step_date")]
+		public long? CurrentStepDate { get; set; }
 	}
 
 	public class ShippingDetails

--- a/src/EtsyAccessTests/OrdersServiceTests.cs
+++ b/src/EtsyAccessTests/OrdersServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using FluentAssertions;
 using NUnit.Framework;
@@ -7,15 +8,27 @@ namespace EtsyAccessTests
 {
 	public class OrdersServiceTests : BaseTest
 	{
-		[Test]
+		[ Test ]
 		public void GetOrders()
 		{
-			DateTime startDate = DateTime.Now.AddMonths(-1);
-			DateTime endDate = DateTime.Now;
+			var startDate = DateTime.Now.AddDays( -1 );
+			var endDate = DateTime.Now;
 
 			var orders = this.EtsyOrdersService.GetOrders( startDate, endDate, CancellationToken.None );
 
 			orders.Should().NotBeNullOrEmpty();
+		}
+
+		[ Test ]
+		public void GetOrdersWithShipments()
+		{
+			var startDate = DateTime.Now.AddDays( -30 );
+			var endDate = DateTime.Now;
+
+			var orders = this.EtsyOrdersService.GetOrders( startDate, endDate, CancellationToken.None );
+			var ordersWithShipments = orders.Where( o => o.Shipments.Any() ).ToList();
+
+			ordersWithShipments.Count.Should().BeGreaterThan( 0 );
 		}
 	}
 }


### PR DESCRIPTION
**Summary**
Tracking number and carrier name is a part of Etsy's order's shipment. It looks that Etsy doesn't support orders (receipts) with multiple shipments because shipment doesn't contain information about shipped items.