### PR TITLE
2020-09-25 GUARD-797 Value-For-Products-Was-Not-A-Valid-JSON

### DIFF
--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.0.13</Version>
+    <Version>1.0.14</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
-    <AssemblyVersion>1.0.13.0</AssemblyVersion>
+    <AssemblyVersion>1.0.14.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/Models/PropertyValue.cs
+++ b/src/EtsyAccess/Models/PropertyValue.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Linq;
 using Newtonsoft.Json;
 
 namespace EtsyAccess.Models
@@ -37,5 +35,11 @@ namespace EtsyAccess.Models
 		/// </summary>
 		[JsonProperty("values")]
 		public string[] Values { get; set; }
+
+		public PropertyValue DecodeValuesQuotesAndEscape()
+		{
+			this.Values = Values?.Select( v => v.Replace( "&quot;", "\"" ) ).ToArray();
+			return this;
+		}
 	}
 }

--- a/src/EtsyAccess/Services/Items/EtsyItemsService.cs
+++ b/src/EtsyAccess/Services/Items/EtsyItemsService.cs
@@ -84,7 +84,7 @@ namespace EtsyAccess.Services.Items
 				{
 					ProductId = product.Id,
 					Sku = product.Sku,
-					PropertyValues = product.PropertyValues,
+					PropertyValues = DecodePropertyValuesWithQuotesAndEscape( product.PropertyValues ),
 					// currently each product has one offering
 					ListingOffering = new ListingOfferingRequest[]
 					{
@@ -139,6 +139,14 @@ namespace EtsyAccess.Services.Items
 				EtsyLogger.LogTraceException( etsyException );
 				throw etsyException;
 			}
+		}
+
+		private PropertyValue[] DecodePropertyValuesWithQuotesAndEscape( PropertyValue[] properties )
+		{
+			if ( properties == null && !properties.Any() )
+				return properties;
+
+			return properties.Select( p => p.DecodeValuesQuotesAndEscape() ).ToArray();
 		}
 
 		/// <summary>

--- a/src/EtsyAccessTests/ItemsServiceTests.cs
+++ b/src/EtsyAccessTests/ItemsServiceTests.cs
@@ -99,6 +99,22 @@ namespace EtsyAccessTests
 		}
 
 		[ Test ]
+		public void UpdateSkuQuantityWithQuoteInTheOptionName()
+		{
+			int quantity = 2;
+			var testSku = "testsku2-1";
+
+			this.EtsyItemsService.UpdateSkuQuantity( testSku, quantity, CancellationToken.None );
+
+			// assert
+			var inventory = this.EtsyItemsService.GetListingProductBySku( testSku, CancellationToken.None ).GetAwaiter().GetResult();
+
+			inventory.Should().NotBeNull();
+			inventory.Offerings.Should().NotBeNullOrEmpty();
+			inventory.Offerings.First().Quantity.Should().Be( quantity );
+		}
+
+		[ Test ]
 		public void UpdateSkusQuantities()
 		{
 			string sku = "testSku1";

--- a/src/EtsyAccessTests/ModelsTests.cs
+++ b/src/EtsyAccessTests/ModelsTests.cs
@@ -1,5 +1,7 @@
 ﻿using EtsyAccess.Models;
+using FluentAssertions;
 using NUnit.Framework;
+using System.Linq;
 
 namespace EtsyAccessTests
 {
@@ -21,6 +23,20 @@ namespace EtsyAccessTests
 
 			Assert.IsNotNull( listing );
 		}
- 
+
+		[ Test ]
+		public void GivenPropertyValuesWithEncodedQuotes_WhenDecodeValuesQuotesAndEscapeCalled_ThenDecodedPropertyValuesAreReturned()
+		{
+			var propertyValue = new PropertyValue()
+			{
+				Id = 1,
+				Values = new string[] { "10&quot;x4&quot;x&quot;2", "5&quot;x2&quot;x&quot;1" }
+			};
+
+			var decodedPropertyValues = propertyValue.DecodeValuesQuotesAndEscape();
+
+			decodedPropertyValues.Values.First().Should().Be( "10\"x4\"x\"2" );
+			decodedPropertyValues.Values.Last().Should().Be( "5\"x2\"x\"1" );
+		}
 	}
 }


### PR DESCRIPTION
**Summary**
Fixed issue with updating listings inventory where variation option name contains quotes.
It seems like Etsy server has deserialization error because when SV returns the same property values back to the server during listing's inventory update, it throws out "not valid JSON" error.

Example:
`"property_values": [
{
		"property_id": 513,
		"property_name": "Style",
		"scale_id": null,
		"scale_name": null,
		"values": [
			"16&quot;x11&quot;x4&quot; (A029-A)"
		],
		"value_ids": [
			247102164417
		]
	}
],`

After decoding and escaping quotes in the values, the issue disappears.
More information can be also find here: https://groups.google.com/g/etsy-api-v2/c/uewNaskjItc?pli=1
