### PR TITLE
GUARD-910 Orders-Sync-Error-Id-Too-Large

### DIFF
--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.0.14</Version>
+    <Version>1.1.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
-    <AssemblyVersion>1.0.14.0</AssemblyVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/Models/Listing.cs
+++ b/src/EtsyAccess/Models/Listing.cs
@@ -13,7 +13,7 @@ namespace EtsyAccess.Models
 		/// The listing's numeric ID
 		/// </summary>
 		[JsonProperty("listing_id")]
-		public int Id { get; set; }
+		public long Id { get; set; }
 		/// <summary>
 		/// One of active, removed, sold_out, expired, alchemy, edit, create, private, or unavailable.
 		/// </summary>

--- a/src/EtsyAccess/Models/Receipt.cs
+++ b/src/EtsyAccess/Models/Receipt.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using EtsyAccess.Shared;
 using Newtonsoft.Json;
 
@@ -15,7 +13,7 @@ namespace EtsyAccess.Models
 		/// The receipt's numeric ID
 		/// </summary>
 		[JsonProperty("receipt_id")]
-		public int Id { get; set; }
+		public long Id { get; set; }
 		/// <summary>
 		/// The enum of the order type this receipt is associated with.
 		/// </summary>
@@ -25,7 +23,7 @@ namespace EtsyAccess.Models
 		/// The numeric ID of the order this receipt is associated with.
 		/// </summary>
 		[JsonProperty("order_id")]
-		public int OrderId { get; set; }
+		public long OrderId { get; set; }
 		/// <summary>
 		/// Creation time, in epoch seconds.
 		/// </summary>

--- a/src/EtsyAccess/Models/Transaction.cs
+++ b/src/EtsyAccess/Models/Transaction.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace EtsyAccess.Models
 {
@@ -14,7 +11,7 @@ namespace EtsyAccess.Models
 		/// The numeric ID for this transaction
 		/// </summary>
 		[JsonProperty("transaction_id")]
-		public int Id { get; set; }
+		public long Id { get; set; }
 		/// <summary>
 		/// The title of the listing for this transaction
 		/// </summary>
@@ -84,7 +81,7 @@ namespace EtsyAccess.Models
 		/// The numeric ID for the receipt associated to this transaction
 		/// </summary>
 		[JsonProperty("receipt_id")]
-		public int ReceiptId { get; set; }
+		public long ReceiptId { get; set; }
 		/// <summary>
 		/// The shipping cost for this transaction
 		/// </summary>
@@ -104,7 +101,7 @@ namespace EtsyAccess.Models
 		/// The numeric ID for this listing associated to this transaction
 		/// </summary>
 		[JsonProperty("listing_id")]
-		public int ListingId { get; set; }
+		public long ListingId { get; set; }
 		/// <summary>
 		/// True if this transaction was created for an in-person quick sale.
 		/// </summary>
@@ -114,12 +111,12 @@ namespace EtsyAccess.Models
 		/// The numeric ID of seller's feedback
 		/// </summary>
 		[JsonProperty("seller_feedback_id")]
-		public int? SellerFeedbackId { get; set; }
+		public long? SellerFeedbackId { get; set; }
 		/// <summary>
 		/// The numeric ID for the buyer's feedback
 		/// </summary>
 		[JsonProperty("buyer_feedback_id")]
-		public int? BuyerFeedbackId { get; set; }
+		public long? BuyerFeedbackId { get; set; }
 		/// <summary>
 		/// The type of transaction, usually "listing"
 		/// </summary>


### PR DESCRIPTION
Since transaction_id (in an Order) has now exceeded the largest 32-bit int (2147483647) for **all** Etsy accounts, converted it and other fields that might get large to 64-bit long [v.1.1.0]

The only Id we currently import into the app is the receipt Id (aka sale id), and we import it as string, so it shouldn't matter whether it's int or long when it's returned from access. Could've changed all id's to strings, but long seems more logical