### PR TITLE
2020-11-20 GUARD-904 Invalid-Signature

### DIFF
--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <AssemblyVersion>1.1.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/Services/Authentication/OAuthenticator.cs
+++ b/src/EtsyAccess/Services/Authentication/OAuthenticator.cs
@@ -123,10 +123,10 @@ namespace EtsyAccess.Services.Authentication
 		{
 			string signature = null;
 
-			string urlEncoded = EscapeUriData( baseUrl );
-			string encodedParameters = EscapeUriData( string.Join( "&",
+			string urlEncoded = PercentEncodeData( baseUrl );
+			string encodedParameters = PercentEncodeData( string.Join( "&",
 				requestParameters.OrderBy( kv => kv.Key ).Select( item =>
-					($"{ EscapeUriData( item.Key ) }={ EscapeUriData( item.Value ) }") ) ) );
+					($"{ PercentEncodeData( item.Key ) }={ PercentEncodeData( item.Value ) }") ) ) );
 			
 			string baseString = $"{ urlMethod.ToUpper() }&{ urlEncoded }&{ encodedParameters }";
 
@@ -177,7 +177,7 @@ namespace EtsyAccess.Services.Authentication
 		/// </summary>
 		/// <param name="data"></param>
 		/// <returns></returns>
-		private string EscapeUriData( string data )
+		public string PercentEncodeData( string data )
 		{
 			string unreservedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
 			StringBuilder result = new StringBuilder();

--- a/src/EtsyAccess/Services/Authentication/OAuthenticator.cs
+++ b/src/EtsyAccess/Services/Authentication/OAuthenticator.cs
@@ -181,12 +181,15 @@ namespace EtsyAccess.Services.Authentication
 		{
 			string unreservedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
 			StringBuilder result = new StringBuilder();
+			// percent encoding string should be produced by reading byte-by-byte to properly encode UTF-8 chars
+			var rawData = Encoding.UTF8.GetBytes( data );
 
-			foreach ( char symbol in data ) {
+			foreach ( byte symbolByte in rawData ) {
+				var symbol = (char)symbolByte;
 				if ( unreservedChars.IndexOf(symbol) != -1 ) {
 					result.Append( symbol );
 				} else {
-					result.Append('%' + String.Format("{0:X2}", (int)symbol));
+					result.Append('%' + String.Format("{0:X2}", (int)symbolByte));
 				}
 			}
 

--- a/src/EtsyAccessTests/EtsyAccessTests.csproj
+++ b/src/EtsyAccessTests/EtsyAccessTests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="CancellationTokenTests.cs" />
     <Compile Include="ItemsServiceTests.cs" />
     <Compile Include="ModelsTests.cs" />
+    <Compile Include="OAuthTests.cs" />
     <Compile Include="OrdersServiceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SharedMiscTests.cs" />

--- a/src/EtsyAccessTests/OAuthTests.cs
+++ b/src/EtsyAccessTests/OAuthTests.cs
@@ -1,0 +1,36 @@
+﻿using EtsyAccess.Services.Authentication;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EtsyAccessTests
+{
+	[ TestFixture ]
+	public class OAuthTests
+	{
+		private OAuthenticator _authenticator;
+
+		[ SetUp ]
+		public void Init()
+		{
+			this._authenticator = new OAuthenticator( "consumer key", "consumer secret" );
+		}
+
+		[ Test ]
+		public void GivenJsonBodyWithOnlyASCIIChars_WhenPercentEncodeDataIsCalled_ThenCorrectStrIsExpected()
+		{
+			var jsonBody = "{\"product_id\":3882915049,\"sku\":\"testsku1-1\"}";
+
+			var percentEncodedStr = this._authenticator.PercentEncodeData( jsonBody );
+			percentEncodedStr.Should().Be( "%7B%22product_id%22%3A3882915049%2C%22sku%22%3A%22testsku1-1%22%7D" );
+		}
+
+		[ Test ]
+		public void GivenJsonBodyWithNotASCIIChars_WhenPercentEncodeDataIsCalled_ThenCorrectStrIsExpected()
+		{
+			var jsonBody = "{\"property_id\":1,\"property_name\":\"Height\",\"scale_id\":1,\"scale_name\":\"inches\",\"value_ids\":[1021012107079],\"values\":[\"1.5”–1.7”\"]}";
+
+			var percentEncodedStr = this._authenticator.PercentEncodeData( jsonBody );
+			percentEncodedStr.Should().Be( "%7B%22property_id%22%3A1%2C%22property_name%22%3A%22Height%22%2C%22scale_id%22%3A1%2C%22scale_name%22%3A%22inches%22%2C%22value_ids%22%3A%5B1021012107079%5D%2C%22values%22%3A%5B%221.5%E2%80%9D%E2%80%931.7%E2%80%9D%22%5D%7D" );
+		}
+	}
+}


### PR DESCRIPTION
**Summary**
Fixed issue with generating request signature when JSON body contains not-ASCII chars.

Example:
String `1.5”–1.7”` should be percent encoded as `1.5 %E2%80%9D %E2%80%93 1.7 %E2%80%9D `
” - %E2%80%9D
Previously this char was encoded as %201D

More information about percent encoding can be found here:
https://developer.twitter.com/en/docs/authentication/oauth-1-0a/percent-encoding-parameters