### PR TITLE
GUARD-888 [TEMPORARY] Etsy Inv Sync Speedup

### DIFF
--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.0.14</Version>
+    <Version>1.1.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
-    <AssemblyVersion>1.0.14.0</AssemblyVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/Services/Items/IEtsyItemsService.cs
+++ b/src/EtsyAccess/Services/Items/IEtsyItemsService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EtsyAccess.Models;
 using EtsyAccess.Models.Requests;
+using EtsyAccess.Shared;
 
 namespace EtsyAccess.Services.Items
 {
@@ -27,13 +28,14 @@ namespace EtsyAccess.Services.Items
 		/// <returns></returns>
 		Task UpdateSkuQuantityAsync( string sku, int quantity, CancellationToken token );
 
-		/// <summary>
-		///	Updates skus quantities asynchronously
-		/// </summary>
-		/// <param name="skusQuantities">new quantity for each sku</param>
-		/// <param name="token"></param>
-		/// <returns></returns>
-		Task UpdateSkusQuantityAsync( Dictionary< string, int > skusQuantities, CancellationToken token );
+		///  <summary>
+		/// 	Updates skus quantities asynchronously
+		///  </summary>
+		///  <param name="skusQuantities">new quantity for each sku</param>
+		///  <param name="token"></param>
+		///  <param name="mark">mark for log correlation</param>
+		///  <returns></returns>
+		Task UpdateSkusQuantityAsync( Dictionary< string, int > skusQuantities, CancellationToken token, Mark mark = null );
 
 		/// <summary>
 		/// Returns product inventory
@@ -48,8 +50,9 @@ namespace EtsyAccess.Services.Items
 		/// </summary>
 		/// <param name="skus"></param>
 		/// <param name="token"></param>
+		/// <param name="mark">Mark for log correlation</param>
 		/// <returns></returns>
-		Task< IEnumerable< Listing > > GetListingsBySkus( IEnumerable< string > skus, CancellationToken token );
+		Task< IEnumerable< Listing > > GetListingsBySkus( IEnumerable< string > skus, CancellationToken token, Mark mark = null );
 
 		/// <summary>
 		/// Creates a new listing

--- a/src/EtsyAccessTests/ItemsServiceTests.cs
+++ b/src/EtsyAccessTests/ItemsServiceTests.cs
@@ -12,7 +12,7 @@ namespace EtsyAccessTests
 {
 	public class ItemsServiceTests : BaseTest
 	{
-		private const string Sku = "testsku1";
+		private const string Sku = "testsku2";
 
 		[ Test ]
 		[ Ignore( "Creates listings in the real store" ) ]


### PR DESCRIPTION
- Only send inventory updates to Etsy when incoming quantity is different from Etsy quantity
- Receive mark as parameters, instead of generating new ones in methods
- Renamed `GetListingInventoryBySku` to `GetListingInventoryAsync` since it doesn't filter by sku

This temporary PR just shows changes since branching off of GUARD-904. Will close this. If we'll keep the releases separate, then will create a PR into master, if combine then will merge this into a combined PR and create a PR from the combined one into master.